### PR TITLE
Refactor ADT-like type classes

### DIFF
--- a/src/Generics/OneLiner.hs
+++ b/src/Generics/OneLiner.hs
@@ -131,7 +131,7 @@ gmap :: (ADT t (->), Constraints t c)
      => for c -> (forall s. c s => s -> s) -> t -> t
 gmap = generic
 
--- | Map each component of a structure to a monoid, and combine the results.
+-- | Map each component of a structure to an element of a monoid, and combine the results.
 --
 -- If you have a class `Size`, which measures the size of a structure, then this could be the default implementation:
 --

--- a/src/Generics/OneLiner.hs
+++ b/src/Generics/OneLiner.hs
@@ -216,26 +216,6 @@ zipWithA1 :: (ADT1 t (Zip f), Constraints1 t c)
 zipWithA1 for f = dimap Zip runZip $ generic1 for $ dimap runZip Zip f
 
 
-newtype Zip f a b = Zip { runZip :: a -> a -> f b }
-instance Functor f => Profunctor (Zip f) where
-  dimap f g (Zip h) = Zip $ \a1 a2 -> fmap g (h (f a1) (f a2))
-instance Applicative f => GenericRecordProfunctor (Zip f) where
-  unit = Zip $ \_ _ -> pure U1
-  mult (Zip f) (Zip g) = Zip $ \(al :*: ar) (bl :*: br) -> (:*:) <$> f al bl <*> g ar br
-instance Alternative f => GenericNonEmptyProfunctor (Zip f) where
-  plus (Zip f) (Zip g) = Zip h where
-    h (L1 a) (L1 b) = fmap L1 (f a b)
-    h (R1 a) (R1 b) = fmap R1 (g a b)
-    h _ _ = empty
-instance Alternative f => GenericProfunctor (Zip f) where
-  zero = Zip absurd
-  identity = Zip $ \_ _ -> empty
-
-inm2 :: (t -> t -> m) -> t -> t -> Compose Maybe (Const m) a
-inm2 f = Compose .: Just .: Const .: f
-outm2 :: Monoid m => (t -> t -> Compose Maybe (Const m) a) -> t -> t -> m
-outm2 f = maybe mempty getConst .: getCompose .: f
-
 -- | Implement a nullary operator by calling the operator for each component.
 --
 -- @
@@ -310,7 +290,3 @@ createA1' = createA1
 gcotraverse1 :: (ADT1 t (Costar f), Constraints1 t c)
              => for c -> (forall d e s. c s => (f d -> e) -> f (s d) -> s e) -> (f a -> b) -> f (t a) -> t b
 gcotraverse1 for f p = runCostar $ generic1 for (Costar . f . runCostar) (Costar p)
-
-infixr 9 .:
-(.:) :: (c -> d) -> (a -> b -> c) -> (a -> b -> d)
-(.:) = (.) . (.)

--- a/src/Generics/OneLiner.hs
+++ b/src/Generics/OneLiner.hs
@@ -40,13 +40,14 @@ module Generics.OneLiner (
   -- * Generic programming with profunctors
   -- | All the above functions have been implemented using these functions,
   -- using different `profunctor`s.
-  GenericRecordProfunctor(..), record, record1,
-  GenericNonEmptyProfunctor(..), nonEmpty, nonEmpty1,
+  GenericRecordProfunctor(..),
+  GenericNonEmptyProfunctor(..),
   GenericProfunctor(..), generic, generic1,
   -- * Types
-  ADT, ADTNonEmpty, ADTRecord, Constraints,
-  ADT1, ADTNonEmpty1, ADTRecord1, Constraints1,
-  For(..), AnyType
+  ADT, Constraints,
+  ADT1, Constraints1,
+  For(..), AnyType,
+  FunConstraints
 ) where
 
 import GHC.Generics
@@ -69,7 +70,7 @@ import Generics.OneLiner.Internal
 -- @
 --
 -- `create` is `createA` specialized to lists.
-create :: (ADT t, Constraints t c)
+create :: (ADT t (Joker []), Constraints t c)
        => for c -> (forall s. c s => [s]) -> [t]
 create = createA
 
@@ -83,24 +84,24 @@ create = createA
 -- @
 --
 -- `createA` is `generic` specialized to `Joker`.
-createA :: (ADT t, Constraints t c, Alternative f)
+createA :: (ADT t (Joker f), Constraints t c)
         => for c -> (forall s. c s => f s) -> f t
 createA for f = runJoker $ generic for $ Joker f
 
 -- | Generate ways to consume values of type `t`. This is the contravariant version of `createA`.
 --
 -- `consume` is `generic` specialized to `Clown`.
-consume :: (ADT t, Constraints t c, Decidable f)
+consume :: (ADT t (Clown f), Constraints t c)
         => for c -> (forall s. c s => f s) -> f t
 consume for f = runClown $ generic for $ Clown f
 
 -- | `create1` is `createA1` specialized to lists.
-create1 :: (ADT1 t, Constraints1 t c)
+create1 :: (ADT1 t (Joker []), Constraints1 t c)
         => for c -> (forall b s. c s => [b] -> [s b]) -> [a] -> [t a]
 create1 = createA1
 
 -- | `createA1` is `generic1` specialized to `Joker`.
-createA1 :: (ADT1 t, Constraints1 t c, Alternative f)
+createA1 :: (ADT1 t (Joker f), Constraints1 t c)
          => for c -> (forall b s. c s => f b -> f (s b)) -> f a -> f (t a)
 createA1 for f = dimap Joker runJoker $ generic1 for $ dimap runJoker Joker f
 
@@ -118,7 +119,7 @@ createA_ :: (FunConstraints t c, Applicative f)
 createA_ for run = autoApply for run . pure
 
 -- | `consume1` is `generic1` specialized to `Clown`.
-consume1 :: (ADT1 t, Constraints1 t c, Decidable f)
+consume1 :: (ADT1 t (Clown f), Constraints1 t c)
          => for c -> (forall b s. c s => f b -> f (s b)) -> f a -> f (t a)
 consume1 for f = dimap Clown runClown $ generic1 for $ dimap runClown Clown f
 
@@ -126,7 +127,7 @@ consume1 for f = dimap Clown runClown $ generic1 for $ dimap runClown Clown f
 -- | Map over a structure, updating each component.
 --
 -- `gmap` is `generic` specialized to @(->)@.
-gmap :: (ADT t, Constraints t c)
+gmap :: (ADT t (->), Constraints t c)
      => for c -> (forall s. c s => s -> s) -> t -> t
 gmap = generic
 
@@ -139,14 +140,14 @@ gmap = generic
 -- @
 --
 -- `gfoldMap` is `gtraverse` specialized to `Const`.
-gfoldMap :: (ADT t, Constraints t c, Monoid m)
+gfoldMap :: (ADT t (Star (Const m)), Constraints t c)
          => for c -> (forall s. c s => s -> m) -> t -> m
 gfoldMap for f = getConst . gtraverse for (Const . f)
 
 -- | Map each component of a structure to an action, evaluate these actions from left to right, and collect the results.
 --
 -- `gtraverse` is `generic` specialized to `Star`.
-gtraverse :: (ADT t, Constraints t c, Applicative f)
+gtraverse :: (ADT t (Star f), Constraints t c)
           => for c -> (forall s. c s => s -> f s) -> t -> f t
 gtraverse for f = runStar $ generic for $ Star f
 
@@ -156,7 +157,7 @@ gtraverse for f = runStar $ generic for $ Star f
 -- @
 --
 -- `gmap1` is `generic1` specialized to @(->)@.
-gmap1 :: (ADT1 t, Constraints1 t c)
+gmap1 :: (ADT1 t (->), Constraints1 t c)
      => for c -> (forall d e s. c s => (d -> e) -> s d -> s e) -> (a -> b) -> t a -> t b
 gmap1 = generic1
 
@@ -166,7 +167,7 @@ gmap1 = generic1
 -- @
 --
 -- `gfoldMap1` is `gtraverse1` specialized to `Const`.
-gfoldMap1 :: (ADT1 t, Constraints1 t c, Monoid m)
+gfoldMap1 :: (ADT1 t (Star (Const m)), Constraints1 t c)
           => for c -> (forall s b. c s => (b -> m) -> s b -> m) -> (a -> m) -> t a -> m
 gfoldMap1 for f = dimap (Const .) (getConst .) $ gtraverse1 for $ dimap (getConst .) (Const .) f
 
@@ -176,7 +177,7 @@ gfoldMap1 for f = dimap (Const .) (getConst .) $ gtraverse1 for $ dimap (getCons
 -- @
 --
 -- `gtraverse1` is `generic1` specialized to `Star`.
-gtraverse1 :: (ADT1 t, Constraints1 t c, Applicative f)
+gtraverse1 :: (ADT1 t (Star f), Constraints1 t c)
            => for c -> (forall d e s. c s => (d -> f e) -> s d -> f (s e)) -> (a -> f b) -> t a -> f (t b)
 gtraverse1 for f = dimap Star runStar $ generic1 for $ dimap runStar Star f
 
@@ -188,13 +189,13 @@ gtraverse1 for f = dimap Star runStar $ generic1 for $ dimap runStar Star f
 -- @
 --
 -- `mzipWith` is `zipWithA` specialized to @`Compose` `Maybe` (`Const` m)@
-mzipWith :: (ADT t, Constraints t c, Monoid m)
+mzipWith :: (ADT t (Zip (Compose Maybe (Const m))), Constraints t c, Monoid m)
          => for c -> (forall s. c s => s -> s -> m) -> t -> t -> m
 mzipWith for f = outm2 $ zipWithA for $ inm2 f
 
 -- | Combine two values by combining each component of the structures with the given function, under an applicative effect.
 -- Returns `empty` if the constructors don't match.
-zipWithA :: (ADT t, Constraints t c, Alternative f)
+zipWithA :: (ADT t (Zip f), Constraints t c)
          => for c -> (forall s. c s => s -> s -> f s) -> t -> t -> f t
 zipWithA for f = runZip $ generic for $ Zip f
 
@@ -204,12 +205,12 @@ zipWithA for f = runZip $ generic for $ Zip f
 -- @
 --
 -- `mzipWith1` is `zipWithA1` specialized to @`Compose` `Maybe` (`Const` m)@
-mzipWith1 :: (ADT1 t, Constraints1 t c, Monoid m)
+mzipWith1 :: (ADT1 t (Zip (Compose Maybe (Const m))), Constraints1 t c, Monoid m)
           => for c -> (forall s b. c s => (b -> b -> m) -> s b -> s b -> m)
           -> (a -> a -> m) -> t a -> t a -> m
 mzipWith1 for f = dimap inm2 outm2 $ zipWithA1 for $ dimap outm2 inm2 f
 
-zipWithA1 :: (ADT1 t, Constraints1 t c, Alternative f)
+zipWithA1 :: (ADT1 t (Zip f), Constraints1 t c)
           => for c -> (forall d e s. c s => (d -> d -> f e) -> s d -> s d -> f (s e))
           -> (a -> a -> f b) -> t a -> t a -> f (t b)
 zipWithA1 for f = dimap Zip runZip $ generic1 for $ dimap runZip Zip f
@@ -242,20 +243,20 @@ outm2 f = maybe mempty getConst .: getCompose .: f
 -- `fromInteger` i = `nullaryOp` (`For` :: `For` `Num`) (`fromInteger` i)
 -- @
 --
--- `nullaryOp` is `record` specialized to `Tagged`.
-nullaryOp :: (ADTRecord t, Constraints t c)
+-- `nullaryOp` is `generic` specialized to `Tagged`.
+nullaryOp :: (ADT t Tagged, Constraints t c)
           => for c -> (forall s. c s => s) -> t
-nullaryOp for f = unTagged $ record for $ Tagged f
+nullaryOp for f = unTagged $ generic for $ Tagged f
 
 -- | Implement a unary operator by calling the operator on the components.
--- This is here for consistency, it is the same as `record`.
+-- This is here for consistency, it is the same as `generic` and `gmap`.
 --
 -- @
 -- `negate` = `unaryOp` (`For` :: `For` `Num`) `negate`
 -- @
-unaryOp :: (ADTRecord t, Constraints t c)
+unaryOp :: (ADT t (->), Constraints t c)
         => for c -> (forall s. c s => s -> s) -> t -> t
-unaryOp = record
+unaryOp = generic
 
 -- | Implement a binary operator by calling the operator on the components.
 --
@@ -265,23 +266,14 @@ unaryOp = record
 -- @
 --
 -- `binaryOp` is `algebra` specialized to pairs.
-binaryOp :: (ADTRecord t, Constraints t c)
+binaryOp :: (ADT t (Costar Pair), Constraints t c)
          => for c -> (forall s. c s => s -> s -> s) -> t -> t -> t
 binaryOp for f = algebra for (\(Pair a b) -> f a b) .: Pair
 
--- | Create a value of a record type (with exactly one constructor), given
--- how to construct the components, under an applicative effect.
---
--- Here's how to implement `get` from the `binary` package:
---
--- @
--- get = `createA'` (`For` :: `For` Binary) get
--- @
---
--- `createA'` is `record` specialized to `Joker`.
-createA' :: (ADTRecord t, Constraints t c, Applicative f)
-         => for c -> (forall s. c s => f s) -> f t
-createA' for f = runJoker $ record for $ Joker f
+-- | 'createA'' is the same as 'createA'. For backwards compatibility.
+createA' :: (ADT t (Joker f), Constraints t c)
+        => for c -> (forall s. c s => f s) -> f t
+createA' = createA
 
 data Pair a = Pair a a
 instance Functor Pair where
@@ -293,20 +285,20 @@ instance Functor Pair where
 -- `binaryOp` for f l r = `algebra` for (\\(Pair a b) -> f a b) (Pair l r)
 -- @
 --
--- `algebra` is `record` specialized to `Costar`.
-algebra :: (ADTRecord t, Constraints t c, Functor f)
+-- `algebra` is `generic` specialized to `Costar`.
+algebra :: (ADT t (Costar f), Constraints t c)
         => for c -> (forall s. c s => f s -> s) -> f t -> t
-algebra for f = runCostar $ record for $ Costar f
+algebra for f = runCostar $ generic for $ Costar f
 
--- | `dialgebra` is `record` specialized to @`Biff` (->)@.
-dialgebra :: (ADTRecord t, Constraints t c, Functor f, Applicative g)
+-- | `dialgebra` is `generic` specialized to @`Biff` (->)@.
+dialgebra :: (ADT t (Biff (->) f g), Constraints t c)
         => for c -> (forall s. c s => f s -> g s) -> f t -> g t
-dialgebra for f = runBiff $ record for $ Biff f
+dialgebra for f = runBiff $ generic for $ Biff f
 
--- | `createA1'` is `record1` specialized to `Joker`.
-createA1' :: (ADTRecord1 t, Constraints1 t c, Applicative f)
-         => for c -> (forall b s. c s => f b -> f (s b)) -> f a -> f (t a)
-createA1' for f = dimap Joker runJoker $ record1 for $ dimap runJoker Joker f
+-- | `createA1'` is the same as `createA1`. For backwards compatibility.
+createA1' :: (ADT1 t (Joker f), Constraints1 t c)
+          => for c -> (forall b s. c s => f b -> f (s b)) -> f a -> f (t a)
+createA1' = createA1
 
 -- |
 --
@@ -314,10 +306,10 @@ createA1' for f = dimap Joker runJoker $ record1 for $ dimap runJoker Joker f
 -- cotraverse = `gcotraverse1` (`For` :: `For` `Distributive`) `cotraverse`
 -- @
 --
--- `gcotraverse1` is `record1` specialized to `Costar`.
-gcotraverse1 :: (ADTRecord1 t, Constraints1 t c, Functor f)
+-- `gcotraverse1` is `generic1` specialized to `Costar`.
+gcotraverse1 :: (ADT1 t (Costar f), Constraints1 t c)
              => for c -> (forall d e s. c s => (f d -> e) -> f (s d) -> s e) -> (f a -> b) -> f (t a) -> t b
-gcotraverse1 for f p = runCostar $ record1 for (Costar . f . runCostar) (Costar p)
+gcotraverse1 for f p = runCostar $ generic1 for (Costar . f . runCostar) (Costar p)
 
 infixr 9 .:
 (.:) :: (c -> d) -> (a -> b -> c) -> (a -> b -> d)

--- a/src/Generics/OneLiner/Internal.hs
+++ b/src/Generics/OneLiner/Internal.hs
@@ -268,6 +268,35 @@ type Constraints1 t c = Constraints1' (Rep1 t) c
 
 -- | `ADT` is a constraint type synonym. The `Generic` instance can be derived,
 -- and any generic representation will be an instance of `ADT'` and `AnyType`.
+-- @'ProfunctorConstraints' t@ reduces to 'GenericRecordProfunctor',
+-- 'GenericNonEmptyProfunctor', or 'GenericProfunctor', depending on the number
+-- of constructors of @t@.
+--
+-- The following list shows how to satisfy 'ADT' constraints used in one-liner.
+--
+-- For instance, @'ADT' t ('Clown' f)@ is entailed by @'Divisible' f@ if @t@ is
+-- a generic data type with a unique constructor, and by @'Decidable' f@
+-- in other cases (0 or more constructors).
+--
+-- The constraints @'ADT' t 'Costar'@ and @'ADT' t 'Tagged'@ are only satisfied
+-- by types @t@ with a unique constructor.
+--
+-- @
+-- 'ADT' t ('Clown'  f) -: 'Divisible' f    -- if t has a unique constructor
+--                  -: 'Decidable' f    -- otherwise
+-- 'ADT' t ('Costar' f) -: 'Functor' f      -- if t has a unique constructor
+-- 'ADT' t ('Joker'  f) -: 'Applicative' f  -- if t has a unique constructor
+--                  -: 'Alternative' f  -- otherwise
+-- 'ADT' t ('Star'   f) -: 'Applicative' f
+-- 'ADT' t ('Zip'    f) -: 'Applicative' f  -- if t has a unique constructor
+--                  -: 'Alternative' f  -- otherwise
+--
+-- 'ADT' t 'Tagged' -: ()                 -- if t has a unique constructor
+-- 'ADT' t (->)   -: ()
+--
+-- 'ADT' t ('Star' ('Const' m))               -: 'Monoid' m
+-- 'ADT' t ('Zip' ('Compose' 'Maybe' ('Const' m)) -: 'Monoid' m
+-- @
 type ADT t p = (Generic t, ADT' (Rep t), Constraints t AnyType, ProfunctorConstraints t p)
 
 type ADT1 t p = (Generic1 t, ADT1' (Rep1 t), Constraints1 t AnyType, ProfunctorConstraints1 t p)

--- a/src/Generics/OneLiner/Internal.hs
+++ b/src/Generics/OneLiner/Internal.hs
@@ -48,16 +48,34 @@ type instance Constraints' (f :*: g) c = (Constraints' f c, Constraints' g c)
 type instance Constraints' (K1 i a) c = c a
 type instance Constraints' (M1 i t f) c = Constraints' f c
 
+type family ProfunctorConstraints' (t :: * -> *) (p :: * -> * -> *) :: Constraint
+type instance ProfunctorConstraints' V1 p = GenericProfunctor p
+type instance ProfunctorConstraints' U1 p = GenericRecordProfunctor p
+type instance ProfunctorConstraints' (f :+: g) p
+  = (GenericNonEmptyProfunctor p, ProfunctorConstraints' f p, ProfunctorConstraints' g p)
+type instance ProfunctorConstraints' (f :*: g) p
+  = (GenericRecordProfunctor p, ProfunctorConstraints' f p, ProfunctorConstraints' g p)
+type instance ProfunctorConstraints' (K1 i c) p = GenericRecordProfunctor p
+type instance ProfunctorConstraints' (M1 i t f) p
+  = (Profunctor p, ProfunctorConstraints' f p)
+
+type family ProfunctorConstraints1' (t :: * -> *) (p :: * -> * -> *) :: Constraint
+type instance ProfunctorConstraints1' V1 p = GenericProfunctor p
+type instance ProfunctorConstraints1' U1 p = GenericRecordProfunctor p
+type instance ProfunctorConstraints1' (f :+: g) p
+  = (GenericNonEmptyProfunctor p, ProfunctorConstraints1' f p, ProfunctorConstraints1' g p)
+type instance ProfunctorConstraints1' (f :*: g) p
+  = (GenericRecordProfunctor p, ProfunctorConstraints1' f p, ProfunctorConstraints1' g p)
+type instance ProfunctorConstraints1' (f :.: g) p
+  = (Profunctor p, ProfunctorConstraints1' g p)
+type instance ProfunctorConstraints1' Par1 p = Profunctor p
+type instance ProfunctorConstraints1' (Rec1 f) p = GenericProfunctor p
+type instance ProfunctorConstraints1' (K1 i c) p = GenericProfunctor p
+type instance ProfunctorConstraints1' (M1 i t f) p
+  = (Profunctor p, ProfunctorConstraints1' f p)
+
 class ADT' (t :: * -> *) where
-  generic' :: (Constraints' t c, GenericProfunctor p)
-    => for c -> (forall s. c s => p s s) -> p (t x) (t x)
-
-class ADTNonEmpty' (t :: * -> *) where
-  nonEmpty' :: (Constraints' t c, GenericNonEmptyProfunctor p)
-    => for c -> (forall s. c s => p s s) -> p (t x) (t x)
-
-class ADTRecord' (t :: * -> *) where
-  record' :: (Constraints' t c, GenericRecordProfunctor p)
+  generic' :: (Constraints' t c, ProfunctorConstraints' t p)
     => for c -> (forall s. c s => p s s) -> p (t x) (t x)
 
 instance ADT' V1 where generic' _ _ = zero
@@ -66,18 +84,6 @@ instance (ADT' f, ADT' g) => ADT' (f :+: g) where generic' for f = plus (generic
 instance (ADT' f, ADT' g) => ADT' (f :*: g) where generic' for f = mult (generic' for f) (generic' for f)
 instance ADT' (K1 i v) where generic' _ = dimap unK1 K1
 instance ADT' f => ADT' (M1 i t f) where generic' for f = dimap unM1 M1 (generic' for f)
-
-instance ADTNonEmpty' U1 where nonEmpty' _ _ = unit
-instance (ADTNonEmpty' f, ADTNonEmpty' g) => ADTNonEmpty' (f :+: g) where nonEmpty' for f = plus (nonEmpty' for f) (nonEmpty' for f)
-instance (ADTNonEmpty' f, ADTNonEmpty' g) => ADTNonEmpty' (f :*: g) where nonEmpty' for f = mult (nonEmpty' for f) (nonEmpty' for f)
-instance ADTNonEmpty' (K1 i v) where nonEmpty' _ = dimap unK1 K1
-instance ADTNonEmpty' f => ADTNonEmpty' (M1 i t f) where nonEmpty' for f = dimap unM1 M1 (nonEmpty' for f)
-
-instance ADTRecord' U1 where record' _ _ = unit
-instance (ADTRecord' f, ADTRecord' g) => ADTRecord' (f :*: g) where record' for f = mult (record' for f) (record' for f)
-instance ADTRecord' (K1 i v) where record' _ = dimap unK1 K1
-instance ADTRecord' f => ADTRecord' (M1 i t f) where record' for f = dimap unM1 M1 (record' for f)
-
 
 type family Constraints1' (t :: * -> *) (c :: (* -> *) -> Constraint) :: Constraint
 type instance Constraints1' V1 c = ()
@@ -91,15 +97,7 @@ type instance Constraints1' (K1 i v) c = ()
 type instance Constraints1' (M1 i t f) c = Constraints1' f c
 
 class ADT1' (t :: * -> *) where
-  generic1' :: (Constraints1' t c, GenericProfunctor p)
-    => for c -> (forall d e s. c s => p d e -> p (s d) (s e)) -> p a b -> p (t a) (t b)
-
-class ADTNonEmpty1' (t :: * -> *) where
-  nonEmpty1' :: (Constraints1' t c, GenericNonEmptyProfunctor p)
-    => for c -> (forall d e s. c s => p d e -> p (s d) (s e)) -> p a b -> p (t a) (t b)
-
-class ADTRecord1' (t :: * -> *) where
-  record1' :: (Constraints1' t c, GenericRecordProfunctor p)
+  generic1' :: (Constraints1' t c, ProfunctorConstraints1' t p)
     => for c -> (forall d e s. c s => p d e -> p (s d) (s e)) -> p a b -> p (t a) (t b)
 
 instance ADT1' V1 where generic1' _ _ _ = zero
@@ -111,22 +109,6 @@ instance ADT1' Par1 where generic1' _ _ = dimap unPar1 Par1
 instance ADT1' (Rec1 f) where generic1' _ f p = dimap unRec1 Rec1 (f p)
 instance ADT1' (K1 i v) where generic1' _ _ _ = dimap unK1 K1 identity
 instance ADT1' f => ADT1' (M1 i t f) where generic1' for f p = dimap unM1 M1 (generic1' for f p)
-
-instance ADTNonEmpty1' U1 where nonEmpty1' _ _ _ = unit
-instance (ADTNonEmpty1' f, ADTNonEmpty1' g) => ADTNonEmpty1' (f :+: g) where nonEmpty1' for f p = plus (nonEmpty1' for f p) (nonEmpty1' for f p)
-instance (ADTNonEmpty1' f, ADTNonEmpty1' g) => ADTNonEmpty1' (f :*: g) where nonEmpty1' for f p = mult (nonEmpty1' for f p) (nonEmpty1' for f p)
-instance ADTNonEmpty1' g => ADTNonEmpty1' (f :.: g) where nonEmpty1' for f p = dimap unComp1 Comp1 $ f (nonEmpty1' for f p)
-instance ADTNonEmpty1' Par1 where nonEmpty1' _ _ = dimap unPar1 Par1
-instance ADTNonEmpty1' (Rec1 f) where nonEmpty1' _ f p = dimap unRec1 Rec1 (f p)
-instance ADTNonEmpty1' f => ADTNonEmpty1' (M1 i t f) where nonEmpty1' for f p = dimap unM1 M1 (nonEmpty1' for f p)
-
-instance ADTRecord1' U1 where record1' _ _ _ = unit
-instance (ADTRecord1' f, ADTRecord1' g) => ADTRecord1' (f :*: g) where record1' for f p = mult (record1' for f p) (record1' for f p)
-instance ADTRecord1' g => ADTRecord1' (f :.: g) where record1' for f p = dimap unComp1 Comp1 $ f (record1' for f p)
-instance ADTRecord1' Par1 where record1' _ _ = dimap unPar1 Par1
-instance ADTRecord1' (Rec1 f) where record1' _ f p = dimap unRec1 Rec1 (f p)
-instance ADTRecord1' f => ADTRecord1' (M1 i t f) where record1' for f p = dimap unM1 M1 (record1' for f p)
-
 
 absurd :: V1 a -> b
 absurd = \case {}
@@ -243,29 +225,19 @@ instance GenericProfunctor Ctor where
   zero = Ctor (const 0) 0
   identity = Ctor (const 0) 1
 
-record :: (ADTRecord t, Constraints t c, GenericRecordProfunctor p)
-       => for c -> (forall s. c s => p s s) -> p t t
-record for f = dimap from to $ record' for f
-
-record1 :: (ADTRecord1 t, Constraints1 t c, GenericRecordProfunctor p)
-        => for c -> (forall d e s. c s => p d e -> p (s d) (s e)) -> p a b -> p (t a) (t b)
-record1 for f p = dimap from1 to1 $ record1' for f p
-
-nonEmpty :: (ADTNonEmpty t, Constraints t c, GenericNonEmptyProfunctor p)
-         => for c -> (forall s. c s => p s s) -> p t t
-nonEmpty for f = dimap from to $ nonEmpty' for f
-
-nonEmpty1 :: (ADTNonEmpty1 t, Constraints1 t c, GenericNonEmptyProfunctor p)
-          => for c -> (forall d e s. c s => p d e -> p (s d) (s e)) -> p a b -> p (t a) (t b)
-nonEmpty1 for f p = dimap from1 to1 $ nonEmpty1' for f p
-
-generic :: (ADT t, Constraints t c, GenericProfunctor p)
+generic :: ADTConstraints t p c
         => for c -> (forall s. c s => p s s) -> p t t
 generic for f = dimap from to $ generic' for f
 
-generic1 :: (ADT1 t, Constraints1 t c, GenericProfunctor p)
+generic1 :: ADTConstraints1 t p c
          => for c -> (forall d e s. c s => p d e -> p (s d) (s e)) -> p a b -> p (t a) (t b)
 generic1 for f p = dimap from1 to1 $ generic1' for f p
+
+type ADTConstraints t p c = (ADT t p, Constraints t c)
+type ADTConstraints1 t p c = (ADT1 t p, Constraints1 t c)
+
+type ProfunctorConstraints t p = (ProfunctorConstraints' (Rep t) p, Profunctor p)
+type ProfunctorConstraints1 t p = (ProfunctorConstraints1' (Rep1 t) p, Profunctor p)
 
 -- | `Constraints` is a constraint type synonym, containing the constraint
 -- requirements for an instance for `t` of class `c`.
@@ -274,21 +246,11 @@ type Constraints t c = Constraints' (Rep t) c
 
 type Constraints1 t c = Constraints1' (Rep1 t) c
 
--- | `ADTRecord` is a constraint type synonym. An instance is an `ADT` with *exactly* one constructor.
-type ADTRecord t = (Generic t, ADTRecord' (Rep t), Constraints t AnyType)
-
-type ADTRecord1 t = (Generic1 t, ADTRecord1' (Rep1 t), Constraints1 t AnyType)
-
--- | `ADTNonEmpty` is a constraint type synonym. An instance is an `ADT` with *at least* one constructor.
-type ADTNonEmpty t = (Generic t, ADTNonEmpty' (Rep t), Constraints t AnyType)
-
-type ADTNonEmpty1 t = (Generic1 t, ADTNonEmpty1' (Rep1 t), Constraints1 t AnyType)
-
 -- | `ADT` is a constraint type synonym. The `Generic` instance can be derived,
 -- and any generic representation will be an instance of `ADT'` and `AnyType`.
-type ADT t = (Generic t, ADT' (Rep t), Constraints t AnyType)
+type ADT t p = (Generic t, ADT' (Rep t), Constraints t AnyType, ProfunctorConstraints t p)
 
-type ADT1 t = (Generic1 t, ADT1' (Rep1 t), Constraints1 t AnyType)
+type ADT1 t p = (Generic1 t, ADT1' (Rep1 t), Constraints1 t AnyType, ProfunctorConstraints1 t p)
 
 -- | Tell the compiler which class we want to use in the traversal. Should be used like this:
 --
@@ -305,10 +267,10 @@ data For (c :: k -> Constraint) = For
 -- @
 -- `put` t = `putWord8` (`toEnum` (`ctorIndex` t)) `<>` `gfoldMap` (`For` :: `For` `Binary`) `put` t
 -- @
-ctorIndex :: ADT t => t -> Int
+ctorIndex :: ADT t Ctor => t -> Int
 ctorIndex = index $ generic (For :: For AnyType) (Ctor (const 0) 1)
 
-ctorIndex1 :: ADT1 t => t a -> Int
+ctorIndex1 :: ADT1 t Ctor => t a -> Int
 ctorIndex1 = index $ generic1 (For :: For AnyType) (const $ Ctor (const 0) 1) (Ctor (const 0) 1)
 
 -- | Any type is instance of `AnyType`, you can use it with @For :: For AnyType@
@@ -332,8 +294,8 @@ type family Result t where
 -- | Automatically apply a lifted function to a polymorphic argument as
 -- many times as possible.
 --
--- A constraint `FunConstraint t c` is equivalent to the conjunction of
--- constraints `c s` for every argument type of `t`.
+-- A constraint @'FunConstraint' t c@ is equivalent to the conjunction of
+-- constraints @c s@ for every argument type of @t@.
 --
 -- If @r@ is not a function type:
 --


### PR DESCRIPTION
The result is not 100% satisfactory, because there is now an occurence of the profunctor `p` in the `ADT t p` constraint (previously `ADT t`). This makes type signatures more complex; I hope my comment on the ADT synonym helps with that. That said, this makes a few generalizations:

`createA` and `createA'` are the same, with the `Applicative` or `Alternative` constraint being inferred from the data type `t`. And similarly with `createA1`/`createA1'`.

`gmap` and `unaryOp` are now exactly the same.

`zipWithA` now also works with only `Applicative` when `t` has a single constructor (previously it unconditionally required `Alternative`), making a potential `zipWithA'` unnecessary.

Future changes are potentially simpler because of the reduction in code duplication (in particular thinking about issue #1).

Closes #6.